### PR TITLE
Feature: add additional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This package is currently being maintained for Neos 4.3 LTS. It is stable, we us
 
 # Quickstart
 
-## 1. Add your own derived Node Type. 
+## 1. Add your own derived Node Type.
 
 Here we decided to place the link to your privacy policy in the inspector of the node type of CookieConsent.
 We also specify a tab and a group in which it will appear.
@@ -101,7 +101,7 @@ A simplified example:
 prototype(Vendor.Site:CookieConsent) < prototype(Neos.Fusion:Component) {
     _privacyPolicyHref = /* TODO */
     _privacyPolicyHref.@process.convert = Neos.Neos:ConvertUris
-    
+
     _cookieModalTranslations = /* TODO */
     _language = /* TODO */
     _apps = /* TODO */
@@ -142,7 +142,7 @@ prototype(Vendor.Site:CookieConsent) < prototype(Neos.Fusion:Component) {
 
 ## 5. Translate the modal (optional)
 The cookie consent can be translated. It has reasonable defaults for many languages and will try to determine the language of
- your page automatically (for example by looking at your `<html lang>` attribute. 
+ your page automatically (for example by looking at your `<html lang>` attribute.
  For available translations see [the github repo](https://github.com/KIProtect/klaro/tree/master/src/translations).
 
 Note the fusion key `_cookieModalTranslations`. It reads more properties from the CookieConsent nodetype that we defined in step 1.
@@ -196,7 +196,7 @@ prototype(Vendor.Site:CookieConsent) < prototype(Neos.Fusion:Component) {
 'Vendor.Site:CookieConsent':
   superTypes:
     'Sandstorm.CookieConsent:CookieConsent': true
-  ui: 
+  ui:
     inspector:
       groups:
         smallPopup:
@@ -218,7 +218,7 @@ prototype(Vendor.Site:CookieConsent) < prototype(Neos.Fusion:Component) {
 ```
 
 The easiest way to find out what you can translate is to change the language of the cookieConsent to something that does not exist,
-e.g. "foo" (see in the renderer of the following component, there the language key is passed as a property). In the frontend it 
+e.g. "foo" (see in the renderer of the following component, there the language key is passed as a property). In the frontend it
 will then fail to load translations and tell you the path where it was looking for the translation.
 
 
@@ -271,7 +271,36 @@ collection configurations and add the component to your site (preferably on your
 
 TODO
 
-## 1. Thing to customize
+## 1. Add additional configuration for klaro.js
+
+Add `additionalConfig` property to renderer of `Sandstorm.CookieConsent:Component.CookieConsent`. This  will add/override
+properties to/of Sandstorm.CookieConsent:Klaro.Settings. You can add as many configuration options as you like.
+Take in look into https://github.com/KIProtect/klaro/blob/master/dist/config.js for valid config options.
+
+```
+prototype(Your.Package:Content.CookieConsent) < prototype(Neos.Neos:ContentComponent) {
+    node = ${q(site).children('cookie-consent').get(0)}
+
+    @context {
+        node = ${this.node}
+        appNodes = ${q(Neos.Node.nearestContentCollection(this.node, 'apps')).children()}
+    }
+
+    renderer = Sandstorm.CookieConsent:Component.CookieConsent {
+
+        # The additional config will add/override properties to/of Sandstorm.CookieConsent:Klaro.Settings
+        additionalConfig = Neos.Fusion:DataStructure {
+            acceptAll = ${q(appNodes).count() > 0}
+            hideDeclineAll = ${q(appNodes).count() == 0 || (q(appNodes).count() > 0 && q(node).property('hideDeclineAll'))}
+            cookieName = ${!String.isBlank(q(node).property('cookieName')) ? q(node).property('cookieName') : 'klaro'}
+            cookieExpiresAfterDays = ${!String.isBlank(q(node).property('cookieExpiresAfterDays')) ? q(node).property('cookieExpiresAfterDays') : 365}
+            default = ${q(node).property('default')}
+            mustConsent = ${q(node).property('mustConsent')}
+            storageMethod = ${q(node).property('storageMethod')}
+        }
+    }
+}
+```
 
 ## 2. Thing to customize
 

--- a/Resources/Private/Fusion/CookieConsent.fusion
+++ b/Resources/Private/Fusion/CookieConsent.fusion
@@ -10,6 +10,7 @@ prototype(Sandstorm.CookieConsent:Component.CookieConsent) < prototype(Neos.Fusi
     # probably (almost) fullscreen and can only be closed by taking a decision. But the decision must be informed,
     # so reading of the privacy policy should be possible.
     disableAutoPopup = false
+    additionalConfig = Neos.Fusion:DataStructure
 
     renderer = afx`
         <Sandstorm.CookieConsent:Klaro.Settings
@@ -17,6 +18,7 @@ prototype(Sandstorm.CookieConsent:Component.CookieConsent) < prototype(Neos.Fusi
             language={props.language}
             cookieModalTranslations={props.cookieModalTranslations}
             apps={props.apps}
+            additionalConfig={props.additionalConfig}
         />
         <Sandstorm.CookieConsent:Script.ConvertStringToRegex />
         <Sandstorm.CookieConsent:Script.KlaroJs disableAutoPopup={props.disableAutoPopup} />

--- a/Resources/Private/Fusion/Util/Klaro.Settings.fusion
+++ b/Resources/Private/Fusion/Util/Klaro.Settings.fusion
@@ -8,6 +8,8 @@ prototype(Sandstorm.CookieConsent:Klaro.Settings) < prototype(Neos.Fusion:Compon
 
     apps = null
 
+    additionalConfig = Neos.Fusion:DataStructure
+
     renderer = Neos.Fusion:DataStructure {
         # You can customize the ID of the DIV element that Klaro will create
         # when starting up. If undefined, Klaro will use 'klaro'.
@@ -44,6 +46,7 @@ prototype(Sandstorm.CookieConsent:Klaro.Settings) < prototype(Neos.Fusion:Compon
 
         apps = ${Klaro.createAppConfiguration(props.apps)}
 
+        @apply.additionalConfig = ${props.additionalConfig}
         @process.toJson = ${Json.stringify(value, ['JSON_UNESCAPED_SLASHES'])}
         @process.wrap = ${'<script>var klaroConfig=' + value + ';</script>'}
     }


### PR DESCRIPTION
Make it possible to add klaro.js config options to `Sandstorm.CookieConsent:Klaro.Settings` dynamicly via [Apply Processor](https://docs.neos.io/cms/manual/rendering/fusion?highlight=%40apply#apply)

That way all the desired configuration for klaro.js is pretty much at the same place.